### PR TITLE
Adding lifecycle support for application deployments

### DIFF
--- a/create-deploymentconfig.yml
+++ b/create-deploymentconfig.yml
@@ -9,7 +9,7 @@
     ignore_errors: true
   
   - name: Copy Template
-    copy:
+    template:
       src: "templates/{{ application_name }}.yml"
       dest: "/tmp/{{ application_name }}.yml"
     when: oc_get_template.rc == 1

--- a/create-deploymentconfig.yml
+++ b/create-deploymentconfig.yml
@@ -1,7 +1,7 @@
 - hosts: masters[0]
   vars:
-    project_name: coolstore-dev
     application_name: coolstore
+    lifecycle: dev
   tasks:
   - name: List Template
     shell: "oc get template/{{ application_name }}"
@@ -15,12 +15,12 @@
     when: oc_get_template.rc == 1
   
   - name: Create Template
-    shell: "oc create -f /tmp/{{ application_name }}.yml"
+    shell: "oc create -f /tmp/{{ application_name }}.yml -n {{ application_name }}-{{ lifecycle }}"
     when: oc_get_template.rc == 1
 
   # TODO: This should actually check for the application, not just the
   # template existence.
   - name: Deploy Application
-    shell: "oc new-app {{ application_name }}"
+    shell: "oc new-app {{ application_name }} -n {{ application_name }}-{{ lifecycle }}"
     when: oc_get_template.rc == 1
 

--- a/create-deploymentconfig.yml
+++ b/create-deploymentconfig.yml
@@ -1,4 +1,4 @@
-- hosts: "{{ hostname }}"
+- hosts: masters[0]
   vars:
     project_name: coolstore-dev
     application_name: coolstore

--- a/create-project.yml
+++ b/create-project.yml
@@ -1,4 +1,4 @@
-- hosts: "{{ hostname }}"
+- hosts: masters[0]
   vars:
     project_name: coolstore-dev
   tasks:

--- a/create-project.yml
+++ b/create-project.yml
@@ -1,12 +1,16 @@
 - hosts: masters[0]
   vars:
-    project_name: coolstore-dev
+    application_name: coolstore
+    lifecycle: dev
   tasks:
   - name: List Projects
-    shell: "oc get projects/{{ project_name }}"
+    shell: "oc get projects/{{ application_name }}-{{ lifecycle }}"
     register: oc_get_project
     ignore_errors: true
 
   - name: 'Create Project'
-    command: "oc new-project {{ project_name }}"
+    command: "oc new-project {{ application_name }}-{{ lifecycle }}"
     when: oc_get_project.rc == 1
+  
+  - name: 'Assign Permissions'
+    command: "oc policy add-role-to-user system:image-puller system:serviceaccount:{{ application_name }}-{{ lifecycle }}:default --namespace {{ application_name }}

--- a/create-project.yml
+++ b/create-project.yml
@@ -13,4 +13,4 @@
     when: oc_get_project.rc == 1
   
   - name: 'Assign Permissions'
-    command: "oc policy add-role-to-user system:image-puller system:serviceaccount:{{ application_name }}-{{ lifecycle }}:default --namespace {{ application_name }}
+    command: "oc policy add-role-to-user system:image-puller system:serviceaccount:{{ application_name }}-{{ lifecycle }}:default -n {{ application_name }}"

--- a/get-latest-image-tags.yml
+++ b/get-latest-image-tags.yml
@@ -3,9 +3,21 @@
   shell: skopeo inspect  --authfile ~/.docker/config.json  docker://{{ datacenter_repo }}/{{ project_name }}/{{ item }} | /usr/local/bin/jq '.RepoTags | sort | last' | tr -d '"'
   register: tagname
 
-- name: Save info to all_containers
+
+- name: Save info with latest tag to all_containers
   vars:
       tag: "{{ item }}:{{ tagname.stdout }}"
   set_fact:
     all_images: "{{ all_images|default([]) + [ tag ] }}"
   ignore_errors: yes
+  when: '":" not in item'
+
+
+- name: Save info with custom tag to all_containers
+  vars:
+      tag: "{{ item }}"
+  set_fact:
+    all_images: "{{ all_images|default([]) + [ tag ] }}"
+  ignore_errors: yes
+  when: item  is regex("(\d+\.)(\d+\.)(\d+)")
+

--- a/pull-container-image-remotely.yml
+++ b/pull-container-image-remotely.yml
@@ -1,7 +1,27 @@
-- hosts: "{{ hostname }}"
+- hosts: masters[0]
+  vars:
+    project_name: coolstore
+    datacenter_repo: registry.apps.ocpmcmhub1.net
+    cleanup_images: false
+    container_images: cart
+    target_registry: docker-registry-default.apps.ocpsite2.net
   tasks:
   - name: Verify jq is installed
     command: /usr/local/bin/jq --version
+  
+  - name: Determine route for local registry
+    shell: "oc get routes/docker-registry -n default | grep docker-registry | awk '{print $2}'"
+    register: oc_get_routes
+  
+  - name: List Projects
+    shell: "oc get projects/{{ project_name }}"
+    register: oc_get_project
+    ignore_errors: true
+
+  - name: 'Create Project'
+    command: "oc new-project {{ project_name }}"
+    when: oc_get_project.rc == 1
+   
   - name: Inspect remote container images
     command: "skopeo inspect  --authfile ~/.docker/config.json  docker://{{ datacenter_repo }}/{{ project_name }}/{{ item }}"
     with_items: "{{ container_images }}"

--- a/remote-pull-tasks.yml
+++ b/remote-pull-tasks.yml
@@ -3,7 +3,7 @@
   shell: |
     skopeo copy docker://{{ datacenter_repo }}/{{ project_name }}/{{ item }} docker-daemon:{{ target_registry }}/{{ project_name }}/{{ item }}
   loop: "{{ all_images }}"
-  register: _push_images
+  register: _pulled_images
   async: 600
   poll: 0
 
@@ -14,4 +14,21 @@
   until: _jobs.finished
   delay: 5  # Check every 5 seconds. Adjust as you like.
   retries: 30  # Retry up to 30 times. Adjust as needed.
-  with_items: "{{ _push_images.results }}"
+  with_items: "{{ _pulled_images.results }}"
+  
+- name: Tag image into the namespace
+  command: docker push {{ target_registry }}/{{ project_name }}/{{ item }}
+  loop: "{{ all_images }}"
+  register: _pushed_images
+  async: 600
+  poll: 0
+
+- name: Waiting for container image to be pushed to site
+  async_status:
+    jid: "{{ item.ansible_job_id }}"
+  register: _jobs
+  until: _jobs.finished
+  delay: 5  # Check every 5 seconds. Adjust as you like.
+  retries: 30  # Retry up to 30 times. Adjust as needed.
+  with_items: "{{ _pushed_images.results }}"
+

--- a/tag-images.yml
+++ b/tag-images.yml
@@ -1,13 +1,13 @@
-- hosts: "{{ hostname }}"
+- hosts: masters[0]
+  vars:
+    application_name: coolstore
+    lifecycle: dev
   tasks:
-  - name: Switch to project
-    command: oc project "{{ project_name }}"
-  - name: Build image
-    command:  oc start-build "{{ build_name }}" --wait
-    when: trigger_build
-  - name: Tag current image
-    command: oc tag "{{ current_build  }}" "{{ build_target  }}"
-    when:  not remove_tag
-  - name: Remove image tag
-    command: oc tag -d "{{ build_target  }}"
-    when: remove_tag
+  - name: Get all images
+    command: "oc get is -n {{ application_name }} | awk '{print $1}' | grep -v 'NAME'"
+    register: images
+
+  - name: Tag latest image to lifecycle
+    command: "oc tag {{ item }}:latest {{ item }}:{{ lifecycle }}"
+    with_items:
+      - "{{ images.stdout_lines }}"

--- a/tag-images.yml
+++ b/tag-images.yml
@@ -2,12 +2,10 @@
   vars:
     application_name: coolstore
     lifecycle: dev
+    image: cart
+    tag_from: latest
+    tag_to: dev
   tasks:
-  - name: Get all images
-    command: "oc get is -n {{ application_name }} | awk '{print $1}' | grep -v 'NAME'"
-    register: images
+  - name: Tag Image
+    command: "oc tag {{ image }}:{{ tag_from }} {{ image }}:{{ tag_to }} -n {{ application_name }}"
 
-  - name: Tag latest image to lifecycle
-    command: "oc tag {{ item }}:latest {{ item }}:{{ lifecycle }}"
-    with_items:
-      - "{{ images.stdout_lines }}"

--- a/templates/coolstore.yml
+++ b/templates/coolstore.yml
@@ -23,15 +23,6 @@ objects:
     name: default
 # UI
 - apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: web-ui
-    labels:
-      app: web-ui
-  spec:
-    tags:
-    - name: latest
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: web-ui
@@ -57,7 +48,7 @@ objects:
             value: coolstore-gw
           - name: HOSTNAME_HTTP
             value: web-ui:8080
-          image: web-ui
+          image: docker-registry.default.svc:5000/coolstore/web-ui:latest
           imagePullPolicy: Always
           name: web-ui
           ports:
@@ -123,15 +114,6 @@ objects:
       name: web-ui
 # Coolstore Gateway
 - apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: coolstore-gw
-    labels:
-      app: coolstore-gw
-  spec: {}
-  status:
-    dockerImageRepository: ""
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: coolstore-gw
@@ -157,7 +139,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: library/coolstore-gw:latest
+          image: docker-registry.default.svc:5000/coolstore/coolstore-gw:latest
           livenessProbe:
             httpGet:
               path: /health
@@ -213,15 +195,6 @@ objects:
       name: coolstore-gw
 # Inventory Service
 - apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: inventory
-    labels:
-      app: inventory
-  spec:
-    tags:
-    - name: latest
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: inventory
@@ -265,7 +238,7 @@ objects:
             value: ${INVENTORY_DB_PASSWORD}
           - name: DB_DATABASE
             value: inventorydb
-          image: inventory
+          image: docker-registry.default.svc:5000/coolstore/inventory:latest
           imagePullPolicy: Always
           lifecycle:
             preStop:
@@ -421,15 +394,6 @@ objects:
       deploymentconfig: inventory-postgresql
 # Catalog Service
 - apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: catalog
-    labels:
-      app: catalog
-  spec:
-    tags:
-    - name: latest
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: catalog
@@ -463,7 +427,7 @@ objects:
             value: catalogdb
           - name: DB_SERVER
             value: catalog-mongodb
-          image: catalog
+          image: docker-registry.default.svc:5000/coolstore/catalog:latest
           imagePullPolicy: Always
           name: catalog
           ports:
@@ -631,15 +595,6 @@ objects:
     - type: ConfigChange
 # Cart Service
 - apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: cart
-    labels:
-      app: cart
-  spec:
-    tags:
-    - name: latest
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: cart
@@ -671,7 +626,7 @@ objects:
             value: ${KIE_SERVER_USER}
           - name: KIE_SERVER_PASSWORD
             value: ${KIE_SERVER_PASSWORD}
-          image: cart
+          image: docker-registry.default.svc:5000/coolstore/cart:latest
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 10
@@ -739,15 +694,6 @@ objects:
       deploymentconfig: cart
 # Review Service
 - apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: review
-    labels:
-      app: review
-  spec:
-    tags:
-    - name: latest
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: review
@@ -778,7 +724,7 @@ objects:
           volumeMounts:
             - name: config
               mountPath: /app/config
-          image: review
+          image: docker-registry.default.svc:5000/coolstore/review:latest
           imagePullPolicy: Always
           name: review
           ports:

--- a/templates/coolstore.yml
+++ b/templates/coolstore.yml
@@ -48,7 +48,7 @@ objects:
             value: coolstore-gw
           - name: HOSTNAME_HTTP
             value: web-ui:8080
-          image: docker-registry.default.svc:5000/coolstore/web-ui:latest
+          image: web-ui:latest
           imagePullPolicy: Always
           name: web-ui
           ports:
@@ -88,6 +88,7 @@ objects:
         from:
           kind: ImageStreamTag
           name: web-ui:latest
+          namespace: coolstore
       type: ImageChange
     - type: ConfigChange
 - apiVersion: v1
@@ -139,7 +140,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: docker-registry.default.svc:5000/coolstore/coolstore-gw:latest
+          image: coolstore-gw:latest
           livenessProbe:
             httpGet:
               path: /health
@@ -167,6 +168,7 @@ objects:
         from:
           kind: ImageStreamTag
           name: coolstore-gw:latest
+          namespace: coolstore
       type: ImageChange
     - type: ConfigChange
 - apiVersion: v1
@@ -238,7 +240,7 @@ objects:
             value: ${INVENTORY_DB_PASSWORD}
           - name: DB_DATABASE
             value: inventorydb
-          image: docker-registry.default.svc:5000/coolstore/inventory:latest
+          image: inventory:latest
           imagePullPolicy: Always
           lifecycle:
             preStop:
@@ -296,6 +298,7 @@ objects:
         from:
           kind: ImageStreamTag
           name: inventory:latest
+          namespace: coolstore
       type: ImageChange
     - type: ConfigChange
 - apiVersion: v1
@@ -427,7 +430,7 @@ objects:
             value: catalogdb
           - name: DB_SERVER
             value: catalog-mongodb
-          image: docker-registry.default.svc:5000/coolstore/catalog:latest
+          image: catalog:latest
           imagePullPolicy: Always
           name: catalog
           ports:
@@ -467,6 +470,7 @@ objects:
         from:
           kind: ImageStreamTag
           name: catalog:latest
+          namespace: coolstore
       type: ImageChange
     - type: ConfigChange
 - apiVersion: v1
@@ -626,7 +630,7 @@ objects:
             value: ${KIE_SERVER_USER}
           - name: KIE_SERVER_PASSWORD
             value: ${KIE_SERVER_PASSWORD}
-          image: docker-registry.default.svc:5000/coolstore/cart:latest
+          image: cart:latest
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 10
@@ -677,6 +681,7 @@ objects:
         from:
           kind: ImageStreamTag
           name: cart:latest
+          namespace: coolstore
       type: ImageChange
     - type: ConfigChange
 - apiVersion: v1
@@ -724,7 +729,7 @@ objects:
           volumeMounts:
             - name: config
               mountPath: /app/config
-          image: docker-registry.default.svc:5000/coolstore/review:latest
+          image: review:latest
           imagePullPolicy: Always
           name: review
           ports:
@@ -779,6 +784,7 @@ objects:
         from:
           kind: ImageStreamTag
           name: review:latest
+          namespace: coolstore
       type: ImageChange
     - type: ConfigChange
 - apiVersion: v1

--- a/templates/coolstore.yml
+++ b/templates/coolstore.yml
@@ -48,7 +48,7 @@ objects:
             value: coolstore-gw
           - name: HOSTNAME_HTTP
             value: web-ui:8080
-          image: web-ui:latest
+          image: web-ui:{{ lifecycle }}
           imagePullPolicy: Always
           name: web-ui
           ports:
@@ -87,7 +87,7 @@ objects:
         - web-ui
         from:
           kind: ImageStreamTag
-          name: web-ui:latest
+          name: web-ui:{{ lifecycle }}
           namespace: coolstore
       type: ImageChange
     - type: ConfigChange
@@ -140,7 +140,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: coolstore-gw:latest
+          image: coolstore-gw:{{ lifecycle }}
           livenessProbe:
             httpGet:
               path: /health
@@ -167,7 +167,7 @@ objects:
         - coolstore-gw
         from:
           kind: ImageStreamTag
-          name: coolstore-gw:latest
+          name: coolstore-gw:{{ lifecycle }}
           namespace: coolstore
       type: ImageChange
     - type: ConfigChange
@@ -240,7 +240,7 @@ objects:
             value: ${INVENTORY_DB_PASSWORD}
           - name: DB_DATABASE
             value: inventorydb
-          image: inventory:latest
+          image: inventory:{{ lifecycle }}
           imagePullPolicy: Always
           lifecycle:
             preStop:
@@ -297,7 +297,7 @@ objects:
         - inventory
         from:
           kind: ImageStreamTag
-          name: inventory:latest
+          name: inventory:{{ lifecycle }}
           namespace: coolstore
       type: ImageChange
     - type: ConfigChange
@@ -430,7 +430,7 @@ objects:
             value: catalogdb
           - name: DB_SERVER
             value: catalog-mongodb
-          image: catalog:latest
+          image: catalog:{{ lifecycle }}
           imagePullPolicy: Always
           name: catalog
           ports:
@@ -469,7 +469,7 @@ objects:
         - catalog
         from:
           kind: ImageStreamTag
-          name: catalog:latest
+          name: catalog:{{ lifecycle }}
           namespace: coolstore
       type: ImageChange
     - type: ConfigChange
@@ -630,7 +630,7 @@ objects:
             value: ${KIE_SERVER_USER}
           - name: KIE_SERVER_PASSWORD
             value: ${KIE_SERVER_PASSWORD}
-          image: cart:latest
+          image: cart:{{ lifecycle }}
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 10
@@ -680,7 +680,7 @@ objects:
         - cart
         from:
           kind: ImageStreamTag
-          name: cart:latest
+          name: cart:{{ lifecycle }}
           namespace: coolstore
       type: ImageChange
     - type: ConfigChange
@@ -729,7 +729,7 @@ objects:
           volumeMounts:
             - name: config
               mountPath: /app/config
-          image: review:latest
+          image: review:{{ lifecycle }}
           imagePullPolicy: Always
           name: review
           ports:
@@ -783,7 +783,7 @@ objects:
         - review
         from:
           kind: ImageStreamTag
-          name: review:latest
+          name: review:{{ lifecycle }}
           namespace: coolstore
       type: ImageChange
     - type: ConfigChange


### PR DESCRIPTION
These commits update the deployment configs to use the images from the application_name namespace instead of their own lifecycle namespaces. They also change the parameters on the create playbooks to be aware of lifecycle tags.

The tag_images playbook doesn't work yet, but I'm too tired to mess with it any more. :)